### PR TITLE
[CF-389] Export events as text file to HDFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ java -Dconfig.file="/<file path>/cloudfeeds-ballista.conf" -Dlogback.configurati
          runDate is a date in the format yyyy-MM-dd. Data belonging to this date will be exported. Default value is yesterday.           
   -n <value> | --dbNames <value>
          dbNames is comma separated list of database names to be exported. Default value is all the databases configured.           
-  -o <value> | --overwrite <value>
-         overwrite is a true/false flag. Set this to true to overwrite the output file if already present. Default value is false.           
   --help
          Use this option to get detailed usage information of this utility.
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,8 @@ dependencies {
     compile "org.apache.hadoop:hadoop-client:2.6.0"
     compile "com.github.scopt:scopt_2.10:3.0.0"
     compile 'org.scala-lang:scala-reflect:2.10.4'
-    
+    compile 'com.jcraft:jsch:0.1.51'
+
     testCompile 'junit:junit:4.11'
     testCompile 'org.scalatest:scalatest_2.10:2.1.7'
     testCompile 'org.mockito:mockito-all:1.9.5'

--- a/src/main/scala/com/rackspace/feeds/ballista/CommandProcessor.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/CommandProcessor.scala
@@ -1,22 +1,27 @@
 package com.rackspace.feeds.ballista
 
-import java.io.{PrintWriter, Writer, OutputStream}
+import java.io.{ByteArrayOutputStream, PrintWriter, Writer}
 
 import com.rackspace.feeds.ballista.config.AppConfig.export.from.dbs._
+import com.rackspace.feeds.ballista.config.AppConfig.export.to.hdfs.scp._
 import com.rackspace.feeds.ballista.config.CommandOptions
 import com.rackspace.feeds.ballista.constants.DBProps
-import com.rackspace.feeds.ballista.service.{HDFSClient, DefaultExportSvc}
+import com.rackspace.feeds.ballista.service.{LocalFSClient, DefaultExportSvc}
+import com.rackspace.feeds.ballista.util.{SCPSessionInfo, SCPUtil}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.slf4j.LoggerFactory
 
-import collection.mutable.{ HashMap, MultiMap, Set }
+import scala.collection.mutable.{HashMap, MultiMap, Set}
 
 class CommandProcessor {
 
   val logger = LoggerFactory.getLogger(getClass)
-  val fsClient = new HDFSClient
+  val fsClient = new LocalFSClient
 
+  val scpUtil = new SCPUtil
+  val sessionInfo = new SCPSessionInfo(user, password, host, port, privateKeyFilePath, privateKeyPassPhrase)
+  
   def doProcess(commandOptions: CommandOptions): Unit = {
     logger.info(s"Process is being run with these options $commandOptions")
 
@@ -29,11 +34,11 @@ class CommandProcessor {
       val outputFileLocation = dbConfigMap(dbName)(DBProps.outputFileLocation).replaceFirst("/$", "")
       mm.addBinding(outputFileLocation, dbName)
 
-      dbName -> new DefaultExportSvc(dbName).export(queryParams, commandOptions.overwrite)
+      dbName -> new DefaultExportSvc(dbName).export(queryParams)
     }).toMap
 
     if (commandOptions.dbNames.size == resultMap.keySet.size) {
-      createSuccessFile(resultMap, mm, commandOptions.runDate, commandOptions.overwrite)
+      createSuccessFile(resultMap, mm, commandOptions.runDate)
     } else {
       val dbNamesMissingResults = commandOptions.dbNames.filterNot(resultMap.keySet).mkString(",")
       logger.error("!!!!!! Results missing for some dbNames[$dbNamesMissingResults] !!!!!")
@@ -55,12 +60,10 @@ class CommandProcessor {
    * @param resultMap contains dbName -> <number of records exported> mapping
    * @param outputLocationMap contains an internal mapping of outputFileLocation -> Set[dbName]
    * @param runDate
-   * @param overwrite
    */
   def createSuccessFile(resultMap: Map[String, Long],
                         outputLocationMap: HashMap[String, Set[String]] with MultiMap[String, String],
-                        runDate: DateTime,
-                        overwrite: Boolean): Unit = {
+                        runDate: DateTime): Unit = {
     
     val dateTimeStr = DateTimeFormat.forPattern("yyyy-MM-dd").print(runDate)
     
@@ -68,8 +71,10 @@ class CommandProcessor {
       case (outputFileLocation, dbNameSet) => {
         logger.info(s"Writing success file in $outputFileLocation for databases[${dbNameSet.mkString(",")}]")
         
-        val successFileName = s"$outputFileLocation/$dateTimeStr/_SUCCESS"
-        val writer: Writer = getHDFSWriter(successFileName, overwrite)
+        val successFileName = s"$outputFileLocation/_SUCCESS"
+
+        val localFilePath: String = java.io.File.createTempFile("temp", "_success").getAbsolutePath
+        val writer: Writer = getWriter(localFilePath)
         
         try {
           
@@ -77,17 +82,26 @@ class CommandProcessor {
             val numberOfRecordsWritten = resultMap.getOrElse(dbName, Long.MinValue)
             writer.write(s"$dbName=$numberOfRecordsWritten\n")
           })
-          
+
         } finally {
           writer.close()
         }
-        
+        scpFile(localFilePath, successFileName, dateTimeStr)
+
         logger.info(s"Completed writing success file $successFileName")
       }
     }
   }
   
-  def getHDFSWriter(fileName: String, overwrite: Boolean) = {
-    new PrintWriter(fsClient.getOutputStream(fileName, overwrite))
+  def getWriter(filePath: String) = {
+    new PrintWriter(fsClient.getOutputStream(filePath))
   }
+  
+  def scpFile(localFilePath: String, remoteFilePath: String, newSubDir: String) = {
+    val remoteOutputFileLocation = remoteFilePath.substring(0, remoteFilePath.lastIndexOf("/"))
+    val remoteOutputFileName = remoteFilePath.substring(remoteFilePath.lastIndexOf("/") + 1)
+    
+    scpUtil.scp(sessionInfo, localFilePath, remoteOutputFileName, remoteOutputFileLocation, newSubDir)
+  }
+  
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/config/AppConfig.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/config/AppConfig.scala
@@ -31,7 +31,9 @@ object AppConfig {
 
     val datacenter = config.getString("appConfig.datacenter")
     val daysDataAvailable = config.getInt("appConfig.daysDataAvailable")
-
+    val tempOutputDir = config.getString("appConfig.tempOutputDir").replaceFirst("/$", "")
+    val maxRowLimit = config.getString("appConfig.maxRowLimit")
+    
     object from {
       object dbs {
 
@@ -64,6 +66,16 @@ object AppConfig {
         val coreSitePath = exportToHDFS.getString("coreSitePath")
         val hdfsSitePath = exportToHDFS.getString("hdfsSitePath")
 
+        object scp {
+          private val exportToHDFSScp = exportToHDFS.getConfig("scp")
+
+          val user = exportToHDFSScp.getString("user")
+          val host = exportToHDFSScp.getString("host")
+          val port = exportToHDFSScp.getInt("port")
+          val password = exportToHDFSScp.getString("password")
+          val privateKeyFilePath = exportToHDFSScp.getString("privateKeyFilePath")
+          val privateKeyPassPhrase = exportToHDFSScp.getString("privateKeyPassPhrase")
+        }
       }
     }
 

--- a/src/main/scala/com/rackspace/feeds/ballista/config/CommandOptionsParser.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/config/CommandOptionsParser.scala
@@ -5,8 +5,7 @@ import org.joda.time.format.DateTimeFormat
 import scopt.Read
 
 case class CommandOptions(runDate: DateTime = DateTime.now.minusDays(1).withTimeAtStartOfDay(),
-                          dbNames: Set[String] = AppConfig.export.from.dbs.dbConfigMap.keySet,
-                          overwrite: Boolean = false)
+                          dbNames: Set[String] = AppConfig.export.from.dbs.dbConfigMap.keySet)
 
 object CommandOptionsParser {
 
@@ -49,14 +48,6 @@ object CommandOptionsParser {
           |Available dbNames for this configuration: ${dbNamesSet.mkString(",")}
         """.stripMargin.replaceAll("\n", " ")
       }
-    opt[Boolean]('o', "overwrite") action { (x, c) =>
-        c.copy(overwrite = x) 
-      } text {
-        """
-          |overwrite is a true/false flag.
-          |Set this to true to overwrite the output file if already present
-        """.stripMargin.replaceAll("\n", " ")
-      } 
     help("help") text {
       """
         |Use this option to get detailed usage information of this utility.

--- a/src/main/scala/com/rackspace/feeds/ballista/queries/DBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/DBQuery.scala
@@ -20,5 +20,5 @@ trait DBQuery {
    * @param dataSource
    * @return a database query to extract data
    */
-  def fetch(runDate: DateTime, datacenter: String, dataSource: DataSource): String
+  def fetch(runDate: DateTime, datacenter: String, dataSource: DataSource, maxRowLimit: String): String
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/queries/EntriesDBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/EntriesDBQuery.scala
@@ -5,29 +5,32 @@ import javax.sql.DataSource
 
 import com.rackspace.feeds.ballista.config.CommandOptionsParser
 import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.{DateTimeFormatter, DateTimeFormat}
 import org.slf4j.LoggerFactory
 
 
 class EntriesDBQuery extends DBQuery {
 
+  val dateTimeFormatter: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
   val logger = LoggerFactory.getLogger(getClass)
   
-  override def fetch(runDate: DateTime, datacenter: String, dataSource: DataSource): String = {
+  override def fetch(runDate: DateTime, datacenter: String, dataSource: DataSource, maxRowLimit: String): String = {
     val tableName = getTableName(runDate, dataSource)
     
     logger.debug(s"Preparing query to extract data from partitioned entries table[$tableName] for runDate[$runDate]")
+    val runDateStr = dateTimeFormatter.print(runDate)
     
     if (!isTableExist(tableName, dataSource)) {
       throw new RuntimeException("Partitioned table[$tableName] does not exist")
     }
     s"""
        | COPY (SELECT id, entryid, creationdate, datelastupdated, 
-       |              regexp_replace(entrybody, E'[\\n\\r]+', ' ', 'g')
-       |              feed, array_to_string( categories, '|' ) as categories, 
-       |              eventtype, tenantid, '$datacenter' as dc
+       |              regexp_replace(entrybody, E'[\\n\\r]+', ' ', 'g') as entrybody,
+       |              array_to_string( categories, '|' ) as categories,
+       |              eventtype, tenantid, '$datacenter' as dc,
+       |              feed, '$runDateStr' as date
        |         FROM $tableName
-       |        limit 10)
+       |        limit $maxRowLimit)
        |   TO STDOUT
        | WITH DELIMITER $PG_DELIMITER
      """.stripMargin
@@ -43,7 +46,7 @@ class EntriesDBQuery extends DBQuery {
    */
   private def getTableName(runDate: DateTime, dataSource: DataSource): String = {
 
-    val runDateStr = DateTimeFormat.forPattern("yyyy-MM-dd").print(runDate)
+    val runDateStr = dateTimeFormatter.print(runDate)
 
     var connection:Connection  = null
   

--- a/src/main/scala/com/rackspace/feeds/ballista/queries/PreferencesDBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/PreferencesDBQuery.scala
@@ -6,11 +6,11 @@ import org.joda.time.DateTime
 
 class PreferencesDBQuery extends DBQuery {
 
-  override def fetch(runDate: DateTime, datacenter: String, dataSource: DataSource): String = {
+  override def fetch(runDate: DateTime, datacenter: String, dataSource: DataSource, maxRowLimit: String): String = {
     s"""
        | COPY (SELECT *
        |         FROM preferences
-       |        limit 10)
+       |        limit $maxRowLimit)
        |   TO STDOUT 
        | WITH DELIMITER ','
      """.stripMargin

--- a/src/main/scala/com/rackspace/feeds/ballista/service/DefaultExportSvc.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/service/DefaultExportSvc.scala
@@ -1,10 +1,13 @@
 package com.rackspace.feeds.ballista.service
 
+import java.io.File
+
 import com.rackspace.feeds.ballista.config.AppConfig
 import com.rackspace.feeds.ballista.config.AppConfig.export.from.dbs.dbConfigMap
+import com.rackspace.feeds.ballista.config.AppConfig.export.to.hdfs.scp._
 import com.rackspace.feeds.ballista.constants.DBProps
 import com.rackspace.feeds.ballista.queries.DBQuery
-import com.rackspace.feeds.ballista.util.DataSourceRepository
+import com.rackspace.feeds.ballista.util.{SCPUtil, SCPSessionInfo, DataSourceRepository}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.slf4j.LoggerFactory
@@ -16,30 +19,47 @@ class DefaultExportSvc(dbName: String) extends ExportSvc {
   val logger = LoggerFactory.getLogger(getClass)
   
   override val dataExport = new PGDataExport
-  override val fsClient = new HDFSClient
+  override val fsClient = new GZFSClient
   lazy val dataSource = DataSourceRepository.getDataSource(dbName)
-  
-  def export(queryParams: Map[String, Any], overwriteFile: Boolean): Long = {
 
-    val outputFilePath = getOutputFilePath(queryParams("runDate").asInstanceOf[DateTime])
+  val scpUtil = new SCPUtil
+  private val sessionInfo = new SCPSessionInfo(user, password, host, port, privateKeyFilePath, privateKeyPassPhrase)
+  
+  def export(queryParams: Map[String, Any]): Long = {
+
+    val runDate: DateTime = queryParams("runDate").asInstanceOf[DateTime]
+    val remoteOutputFilePath = getRemoteOutputFilePath(runDate)
     val query = getQuery(queryParams)
     logger.debug(s"query: $query")
+
+    val tempOutputFilePath = getTempOutputFilePath(remoteOutputFilePath, AppConfig.export.tempOutputDir)
     
-    logger.info(s"Exporting data from db:[$dbName] to HDFS file:[$outputFilePath]")
+    logger.info(s"Exporting data from db:[$dbName] to temporary file:[$tempOutputFilePath]")
     
-    val totalRecords = super.export(dataSource, query, outputFilePath, overwriteFile)
+    val totalRecords = super.export(dataSource, query, tempOutputFilePath)
     
-    logger.info(s"Exported [$totalRecords] records from db:[$dbName] to HDFS file:[$outputFilePath]")
+    logger.info(s"Exported [$totalRecords] records from db:[$dbName] to temporary file:[$tempOutputFilePath]")
+
+    
+    scpFile(tempOutputFilePath, remoteOutputFilePath, DateTimeFormat.forPattern(DATE_FORMAT).print(runDate))
     
     totalRecords
   }
 
-  
+  def scpFile(tempOutputFilePath: String, remoteOutputFilePath: String, subDir: String) {
+    val remoteOutputFileLocation = remoteOutputFilePath.substring(0, remoteOutputFilePath.lastIndexOf("/"))
+    val remoteOutputFileName = remoteOutputFilePath.substring(remoteOutputFilePath.lastIndexOf("/") + 1)
+    
+    logger.info(s"SCP start: local file [$tempOutputFilePath] to remote file [$remoteOutputFileLocation/$subDir]")
+    scpUtil.scp(sessionInfo, tempOutputFilePath, remoteOutputFileName, remoteOutputFileLocation, subDir)
+    logger.info(s"SCP completed successfully: [$tempOutputFilePath] to remote file [$remoteOutputFileLocation/$subDir]")
+  }
+
   private def getQuery(queryParams: Map[String, Any]) = {
     val dbQuery = getInstance(dbConfigMap(dbName)(DBProps.queryClass))
     val datacenter = AppConfig.export.datacenter
   
-    dbQuery.fetch(queryParams("runDate").asInstanceOf[DateTime], datacenter, dataSource)
+    dbQuery.fetch(queryParams("runDate").asInstanceOf[DateTime], datacenter, dataSource, AppConfig.export.maxRowLimit)
   }
 
   /**
@@ -66,13 +86,37 @@ class DefaultExportSvc(dbName: String) extends ExportSvc {
    *
    * @return
    */
-  private def getOutputFilePath(dateTime: DateTime) = {
+  private def getRemoteOutputFilePath(dateTime: DateTime) = {
 
     val outputFileLocation = dbConfigMap(dbName)(DBProps.outputFileLocation).replaceFirst("/$", "")
     val fileNamePrefix = dbConfigMap(dbName)(DBProps.fileNamePrefix)
     val dateTimeStr = DateTimeFormat.forPattern(DATE_FORMAT).print(dateTime)
 
-    s"$outputFileLocation/$dateTimeStr/${fileNamePrefix}_${dbName}_$dateTimeStr.txt".toLowerCase
+    s"$outputFileLocation/${fileNamePrefix}_${dbName}_$dateTimeStr.gz".toLowerCase
   }
-  
+
+  /**
+   * Fetches the file name from the given $remoteOutputFilePath and returns a file path
+   * for the temporary gzip file to be created in in $tempDir location
+   *
+   * @param remoteOutputFilePath
+   * @param tempDir
+   * @return
+   */
+  private def getTempOutputFilePath(remoteOutputFilePath: String, tempDir: String): String = {
+    
+    //Get the file name and change the file extension to .gz
+    val tempFileName = remoteOutputFilePath.substring(remoteOutputFilePath.lastIndexOf("/") + 1)
+
+    val tempOutputFilePath = if (tempDir.length > 0)
+      s"$tempDir/$tempFileName"
+    else
+      tempFileName
+
+    //create any intermediate directories in the path
+    if (tempOutputFilePath.lastIndexOf("/") > 0)
+      new File(tempOutputFilePath.substring(0, tempOutputFilePath.lastIndexOf("/"))).mkdirs()
+    
+    tempOutputFilePath
+  }
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/service/ExportSvc.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/service/ExportSvc.scala
@@ -7,10 +7,10 @@ trait ExportSvc {
   def dataExport: DataExport
   def fsClient: FSClient
 
-  def export(dataSource: DataSource, query: String, outputFilePath: String, overwriteFile: Boolean ): Long = {
+  def export(dataSource: DataSource, query: String, outputFilePath: String): Long = {
 
-    val outputStream = fsClient.getOutputStream(outputFilePath, overwriteFile)
-    
+    val outputStream = fsClient.getOutputStream(outputFilePath)
+
     dataExport.export(dataSource, query, outputStream)
   }
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/service/FSClient.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/service/FSClient.scala
@@ -8,8 +8,7 @@ trait FSClient {
    * Gets output stream for the provided filePath
    *
    * @param filePath
-   * @param overwrite
    * @return output stream
    */
-  def getOutputStream(filePath: String, overwrite: Boolean): OutputStream
+  def getOutputStream(filePath: String): OutputStream
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/service/GZFSClient.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/service/GZFSClient.scala
@@ -1,0 +1,18 @@
+package com.rackspace.feeds.ballista.service
+
+import java.io.{FileOutputStream, File, OutputStream}
+import java.util.zip.GZIPOutputStream
+
+import org.slf4j.LoggerFactory
+
+class GZFSClient extends FSClient {
+
+  val logger = LoggerFactory.getLogger(getClass)
+  
+  override def getOutputStream(outputFilePath: String): OutputStream = {
+
+    val fos: FileOutputStream = new FileOutputStream(outputFilePath)
+    new GZIPOutputStream(fos);
+  }
+
+}

--- a/src/main/scala/com/rackspace/feeds/ballista/service/HDFSClient.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/service/HDFSClient.scala
@@ -1,6 +1,6 @@
 package com.rackspace.feeds.ballista.service
 
-import java.io.{FileOutputStream, File, OutputStream}
+import java.io.{File, OutputStream}
 
 import com.rackspace.feeds.ballista.config.AppConfig
 import org.apache.hadoop.conf.Configuration
@@ -15,10 +15,9 @@ class HDFSClient extends FSClient {
   private val fileSystem = FileSystem.get(conf)
 
 
-  override def getOutputStream(filePath: String, overwrite: Boolean): OutputStream = {
+  override def getOutputStream(filePath: String): OutputStream = {
     val file = new File(filePath)
 
-    fileSystem.create(new Path(filePath), overwrite)
-//    new FileOutputStream(file)
+    fileSystem.create(new Path(filePath))
   }
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/service/LocalFSClient.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/service/LocalFSClient.scala
@@ -1,0 +1,16 @@
+package com.rackspace.feeds.ballista.service
+
+import java.io.{FileOutputStream, OutputStream}
+
+class LocalFSClient extends FSClient {
+  
+  /**
+   * Gets output stream for the provided filePath
+   *
+   * @param filePath
+   * @return output stream
+   */
+  override def getOutputStream(filePath: String): OutputStream = {
+    new FileOutputStream(filePath)
+  }
+}

--- a/src/main/scala/com/rackspace/feeds/ballista/util/SCPSessionInfo.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/util/SCPSessionInfo.scala
@@ -1,0 +1,51 @@
+package com.rackspace.feeds.ballista.util
+
+import java.util.Properties
+
+import com.jcraft.jsch.{UserInfo, Session, JSch}
+
+
+class SCPUserInfo(val password: String) extends UserInfo {
+  override def getPassphrase: String = null
+
+  override def promptPassword(message: String): Boolean = password != null
+
+  override def promptYesNo(message: String): Boolean = false
+
+  override def showMessage(message: String): Unit = {}
+
+  override def getPassword: String = password
+
+  override def promptPassphrase(message: String): Boolean = false
+}
+
+class SCPSessionInfo(userName: String, password: String, host: String, port: Int, pKeyFilePath: String, pKeyPassPhrase: String) {
+
+  private def getConfig() = {
+    val props: Properties = new java.util.Properties
+    props.put("StrictHostKeyChecking", "no")
+
+    props
+  }
+
+  def createSession() = {
+
+    val jsch: JSch = new JSch
+    if (pKeyFilePath != null && pKeyFilePath.length > 0)
+      jsch.addIdentity(pKeyFilePath, pKeyPassPhrase)
+
+    val session: Session = jsch.getSession(userName, host, port)
+
+    session.setConfig(getConfig())
+    session.setUserInfo(new SCPUserInfo(password))
+
+    session
+  }
+
+}
+
+object SCPSessionInfo {
+  def apply(userName: String, password: String, host: String, port: Int, pKeyFilePath: String, pKeyPassPhrase: String) = {
+    new SCPSessionInfo(userName, password, host, port, pKeyFilePath, pKeyPassPhrase)
+  }
+}

--- a/src/main/scala/com/rackspace/feeds/ballista/util/SCPUtil.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/util/SCPUtil.scala
@@ -1,0 +1,172 @@
+package com.rackspace.feeds.ballista.util
+
+import java.io._
+
+import com.jcraft.jsch.{Channel, ChannelExec, Session}
+import org.apache.commons.io.IOUtils
+import org.slf4j.LoggerFactory
+
+import scala.io.Source
+
+class SCPUtil {
+
+  val DefaultBufSize = 1024
+  val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+   * Using $sessionInfo, scp's the file $localFilePath to $remoteFileLocation/$subDir location. 
+   * The file name remains the same.
+   *  
+   * @param sessionInfo
+   * @param localFilePath
+   * @param remoteFileLocation
+   */
+  def scp(sessionInfo: SCPSessionInfo, localFilePath: String, remoteFileName: String, remoteFileLocation: String, subDir: String) = {
+
+    var remoteOutputStream: OutputStream = null
+    var remoteInputStream: InputStream = null
+
+    try {
+      val session: Session = sessionInfo.createSession()
+      session.connect()
+
+      val channel: Channel = openChannelAndSetCommand(remoteFileLocation, session, subDir)
+
+      remoteOutputStream = channel.getOutputStream
+      remoteInputStream = channel.getInputStream
+
+      channel.connect()
+
+      if (isValidTransfer(remoteInputStream)) {
+        logger.debug("channel connection successful")
+      }
+
+      sendFileSize(remoteFileName, localFilePath, remoteOutputStream, remoteInputStream, subDir)
+      sendContent(localFilePath, remoteOutputStream, remoteInputStream)
+      remoteOutputStream.close()
+
+      channel.disconnect()
+      session.disconnect()
+
+    } finally {
+      IOUtils.closeQuietly(remoteOutputStream)
+      IOUtils.closeQuietly(remoteInputStream)
+    }
+  }
+
+
+  private def openChannelAndSetCommand(remoteFileLocation: String, session: Session, subDir: String): Channel = {
+
+    /**
+     *  scp -t is meant for running scp in sink mode on the remote node. These options are for internal
+     *  usage only and aren't documented. I found this link very helpful.
+     *  (https://blogs.oracle.com/janp/entry/how_the_scp_protocol_works)
+     *  
+     *  Jsch library internally parses this command into a String array. So be careful 
+     *  to not include any extra spaces inbetween.
+     */
+    val recursiveCopyFlag = if (subDir != null && subDir.length > 0) 
+      "r" //if directory creating is invovled
+    else 
+      ""
+    
+    val command = s"scp -${recursiveCopyFlag}t $remoteFileLocation"
+    val channel = session.openChannel("exec")
+
+    logger.debug(s"scp command: [$command]")
+    channel.asInstanceOf[ChannelExec].setCommand(command)
+    channel
+  }
+
+  /**
+   * This method sends the raw data to the consumer (scp in sink mode) by writing
+   * to the $remoteOutputStream. The consumer reads exactly that much data as specified 
+   * in the length field previously sent with raw protocol message.
+   *
+   * @param localFilePath
+   * @param remoteOutputStream
+   * @param remoteInputStream
+   */
+  private def sendContent(localFilePath: String, remoteOutputStream: OutputStream, remoteInputStream: InputStream): Unit = {
+    val buf: Array[Byte] = new Array[Byte](DefaultBufSize)
+
+    val inputStream = new FileInputStream(localFilePath)
+    try {
+      Iterator
+        .continually (inputStream.read(buf, 0, buf.length))
+        .takeWhile (-1 !=)
+        .foreach (numberOfBytesRead => remoteOutputStream.write(buf, 0, numberOfBytesRead))
+    } finally {
+      inputStream.close()
+    }
+
+    buf(0) = 0.toByte
+    remoteOutputStream.write(buf, 0, 1)
+    remoteOutputStream.flush()
+
+    if (isValidTransfer(remoteInputStream)) {
+      logger.debug("file content sent successfully")
+    }
+  }
+
+  /**
+   * Sending raw protocol message to scp in sink mode indicating the filename, mode, length
+   * in the below format
+   *
+   * Cmmmm <length> <filename>
+   *  a single file copy, mmmmm is mode(as the one used in chmod command). Example: C0644 299 remote_file_name
+   *  C indicates file copy (D indicates directory)
+   *
+   * Note: filename should not contain "/"
+   *  
+   * after C message the data is expected (unless the file is empty)
+   * after D message either C or E is expected. This means that it's correct to copy an empty directory providing that user used -r option.
+   *
+   * @param localFilePath
+   * @param out
+   * @param in
+   */
+  private def sendFileSize(remoteFileName: String, localFilePath: String, out: OutputStream, in: InputStream, subDir: String) {
+
+    val localFile = new File(localFilePath)
+    val localFileSize = localFile.length()
+
+    val streamCommand = new StringBuilder
+    if (subDir != null && subDir.length > 0)
+      streamCommand.append(s"D0755 0 $subDir\n")
+    streamCommand.append(s"C0644 $localFileSize $remoteFileName\n")
+
+    out.write(streamCommand.toString().getBytes)
+    out.flush()
+
+    if (isValidTransfer(in)) {
+      logger.debug(s"[$streamCommand] message sent successfully")
+    }
+  }
+
+  /**
+   * This method returns true for a valid transfer and throws RuntimeException if not.
+   *
+   * The consumer(scp in sink mode(-t)) can reply in 3 different messages; 
+   * binary 0 (OK), 1 (warning) or 2 (fatal error; will end the connection). 
+   *
+   * Messages 1 and 2 can be followed by a the error message and then followed 
+   * by a new line character.
+   *
+   * @param inputStream
+   * @return true/false indicating a valid transfer
+   */
+  private def isValidTransfer(inputStream: InputStream): Boolean = {
+    inputStream.read match {
+      case 0 => true
+      case anyOtherValue => {
+        val message = Source.fromInputStream(inputStream).getLines().mkString
+        val errorMessage = s"scp -t responded with $anyOtherValue message code followed by error message [$message]"
+        logger.error(errorMessage)
+        throw new RuntimeException(errorMessage)
+      }
+    }
+  }
+
+}
+

--- a/src/test/scala/com/rackspace/feeds/ballista/config/CommandOptionsParserTest.scala
+++ b/src/test/scala/com/rackspace/feeds/ballista/config/CommandOptionsParserTest.scala
@@ -15,7 +15,6 @@ class CommandOptionsParserTest extends FunSuite {
       case Some(commandOptions) =>
         assert(commandOptions.runDate === DateTime.now.minusDays(1).withTimeAtStartOfDay(), "runDate option has the wrong default value")
         assert(commandOptions.dbNames.size === AppConfig.export.from.dbs.dbConfigMap.keySet.size, "dbNames option has the wrong default value")
-        assert(commandOptions.overwrite === false, "overwrite option has the wrong default value")
       case None => fail("Unable to parse command options")
     }
   }
@@ -108,7 +107,6 @@ class CommandOptionsParserTest extends FunSuite {
       case Some(commandOptions) =>
         assert(commandOptions.runDate === runDate, "runDate option is not set to the correct value")
         assert(commandOptions.dbNames === dbNames, "dbNames option is not set to the correct value")
-        assert(commandOptions.overwrite === overwrite, "overwrite option is not set to the correct value")
       case None => fail("Unable to parse command options")
     }
   }

--- a/src/test/scala/com/rackspace/feeds/ballista/util/SCPUtilTest.scala
+++ b/src/test/scala/com/rackspace/feeds/ballista/util/SCPUtilTest.scala
@@ -1,0 +1,24 @@
+package com.rackspace.feeds.ballista.util
+
+import java.io.{ByteArrayInputStream, StringReader}
+
+import com.rackspace.feeds.ballista.config.AppConfig.export.to.hdfs.scp._
+import org.scalatest.{FunSuite, PrivateMethodTester}
+
+class SCPUtilTest  extends FunSuite with PrivateMethodTester {
+  
+  test("should throw exception for an error message from scp") {
+    val errorMessageStream = new ByteArrayInputStream("\u0002Test scp error message'\n".toCharArray.map(_.toByte))
+    val scp:SCPUtil = new SCPUtil
+
+    try {
+      val isValidTransfer = PrivateMethod[Boolean]('isValidTransfer)
+      val isValidTransferResult = scp invokePrivate isValidTransfer(errorMessageStream)
+
+      fail("isValidTransfer did not throw exception")
+
+    } catch {
+      case e: RuntimeException => println(e)
+    }
+  }
+}


### PR DESCRIPTION
 - Added config options for scp
 - Externalized limit on number of rows exported
 - Changed entries query as per specification
 - Instead of writing directly to HDFS file system, creating an intermediate Gzip file.
 - Removed overwrite option as SCP would always overwrite files
 - scp Gzip files using Jsch library