### PR TITLE
CF-566 remaining tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,23 @@
 buildscript {
     repositories {
+        mavenLocal()
+        maven { url "https://maven.research.rackspacecloud.com/content/repositories/snapshots/" }
+        maven { url "https://maven.research.rackspacecloud.com/content/repositories/releases/" }
         mavenCentral()
         jcenter()
+        maven { url 'https://oss.sonatype.org/content/groups/public' }
     }
     dependencies {
         classpath 'com.netflix.nebula:gradle-ospackage-plugin:2.0.3'
     }
 }
 
+plugins {
+    id 'net.researchgate.release' version '2.0.2'
+}
+
 apply plugin: 'scala'
+apply plugin: 'maven'
 apply plugin: 'os-package-base'
 
 repositories {
@@ -18,6 +27,8 @@ repositories {
 
 group = 'com.rackspace.feeds.ballista'
 sourceCompatibility = 1.7
+
+defaultTasks  'clean', 'build'
 
 ext.app_name = 'cloudfeeds-ballista'
 ext.rpmProps = [
@@ -146,6 +157,30 @@ buildRpm.doFirst {
     link(rpmProps.prefix_path + '/lib/' + rpmProps.app_name + '.jar', rpmProps.prefix_path + '/lib/' + version_jar)
 }
 
-compileScala {
-    scalaCompileOptions.additionalParameters = ["-feature"]
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            // nexusUsername and nexusPassword are passed in via -P option when gradle is run
+            repository(url: "https://maven.research.rackspacecloud.com/content/repositories/releases/") {
+                authentication(userName: nexusUsername, password: nexusPassword)
+            }
+            snapshotRepository(url: "https://maven.research.rackspacecloud.com/content/repositories/snapshots/") {
+                authentication(userName: nexusUsername, password: nexusPassword)
+            }
+            pom.groupId    = project.group
+            pom.artifactId = project.name
+            pom.version    = project.version.minus('-SNAPSHOT')
+        }
+    }
 }
+
+release {
+    failOnPublishNeeded = false
+    failOnCommitNeeded = false
+    failOnUnversionedFiles = false
+    tagPrefix = 'cloudfeeds-ballista'
+    // for testing on dev boxes
+    //git.requireBranch = ''
+}
+
+createReleaseTag.dependsOn uploadArchives

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,8 @@
-version = 1.0.0-SNAPSHOT
+#Thu, 05 Mar 2015 12:29:43 -0600
+version=1.0.0
+org.gradle.jvmargs=-XX\:MaxPermSize\=512M
+
+# this is a bogus username/password
+# to make normal development build happy
+nexusUsername=development
+nexusPassword=development

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
-#Thu, 05 Mar 2015 12:29:43 -0600
-version=1.0.0
+version=1.0.0-SNAPSHOT
 org.gradle.jvmargs=-XX\:MaxPermSize\=512M
 
 # this is a bogus username/password

--- a/src/main/scala/com/rackspace/feeds/ballista/config/AppConfig.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/config/AppConfig.scala
@@ -20,7 +20,6 @@ object AppConfig {
 
     logger.info("Loading config from external path:" + System.getProperty("config.file"))
     ConfigFactory.load()
-      .withFallback(classpathConfig)
 
   } else {
     logger.info("Loading config from classpath")


### PR DESCRIPTION
 - [CF-566] Added ability to release artifact
 - Removing fallback on default config. When we have fallback on the default config(classpath), external config overrides the configuration. If we miss defining a database, its picking from the config file present in classpath, which could cause some issues as that file does not have working db configurations.