### PR TITLE
CF-833 create timestamp success file on successful cron run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,8 +114,10 @@ ospackage {
     from('src/main/resources') {
         into 'bin'
         include 'cloudfeeds-ballista.sh'
+        include 'cloudfeeds-ballista_start.sh'
         user rpmProps.app_user
         permissionGroup rpmProps.app_group
+        fileMode 0755
     }
 
     // collect our jars

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ ospackage {
     from('src/main/resources') {
         into 'bin'
         include 'cloudfeeds-ballista.sh'
-        include 'cloudfeeds-ballista_start.sh'
+        include 'cloudfeeds-ballista-cron.sh'
         user rpmProps.app_user
         permissionGroup rpmProps.app_group
         fileMode 0755

--- a/src/main/resources/cloudfeeds-ballista-cron.sh
+++ b/src/main/resources/cloudfeeds-ballista-cron.sh
@@ -7,7 +7,7 @@
 # path where the success file is to be stored on successful execution
 SUCCESS_FILE_PATH="/var/log/cloudfeeds-ballista"
 
-./cloudfeeds-ballista.sh
+`dirname $0`/cloudfeeds-ballista.sh $*
 
 rc=$?
 
@@ -15,3 +15,5 @@ if [ $rc -eq 0 ]; then
     # SUCCESS
     date --iso-8601=seconds --utc > $SUCCESS_FILE_PATH/last_success.txt
 fi
+
+exit $rc

--- a/src/main/resources/cloudfeeds-ballista.sh
+++ b/src/main/resources/cloudfeeds-ballista.sh
@@ -52,9 +52,4 @@ fi
 
 /usr/bin/java $JAVA_OPTS -jar $EXEC_JAR $RUN_OPTS $*
 
-rc=$?
-
-if [ $rc -eq 0 ]; then
-    # SUCCESS
-    date --iso-8601=seconds --utc > $LOG_PATH/last_success.txt
-fi
+exit $?

--- a/src/main/resources/cloudfeeds-ballista.sh
+++ b/src/main/resources/cloudfeeds-ballista.sh
@@ -51,3 +51,10 @@ if [ ! -d "${LOG_PATH}" ]; then
 fi
 
 /usr/bin/java $JAVA_OPTS -jar $EXEC_JAR $RUN_OPTS $*
+
+rc=$?
+
+if [ $rc -eq 0 ]; then
+    # SUCCESS
+    date > $LOG_PATH/last_success.txt
+fi

--- a/src/main/resources/cloudfeeds-ballista.sh
+++ b/src/main/resources/cloudfeeds-ballista.sh
@@ -56,5 +56,5 @@ rc=$?
 
 if [ $rc -eq 0 ]; then
     # SUCCESS
-    date > $LOG_PATH/last_success.txt
+    date --iso-8601=seconds --utc > $LOG_PATH/last_success.txt
 fi

--- a/src/main/resources/cloudfeeds-ballista_start.sh
+++ b/src/main/resources/cloudfeeds-ballista_start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# cloudfeeds-ballista_start:    Script for kicking off cloudfeeds-ballista.sh and creating a success file on exit 0
+#
+#
+
+# path where the success file is to be stored on successful execution
+SUCCESS_FILE_PATH="/var/log/cloudfeeds-ballista"
+
+./cloudfeeds-ballista.sh
+
+rc=$?
+
+if [ $rc -eq 0 ]; then
+    # SUCCESS
+    date --iso-8601=seconds --utc > $SUCCESS_FILE_PATH/last_success.txt
+fi


### PR DESCRIPTION
@shintasmith @usnavi @ChandraAddala 

Simple shell changes for story CF-833 (https://jira.rax.io/browse/CF-833), to create a timestamped "last_success.txt" file on successful ballista cron run.

Questions for you guys: is it ok to put it in the LOGPATH directory  (i.e. /var/log/cloudfeeds-ballista) which is also where the log files are placed?
