### PR TITLE
[CF-938] Requires all non-data files/directories to be prefaced with _

### DIFF
--- a/src/main/resources/cloudfeeds-ballista.conf
+++ b/src/main/resources/cloudfeeds-ballista.conf
@@ -43,7 +43,9 @@ appConfig {
 
           #When this field is set to true, app stores the final output file under $outputFileLocation/$runDate (run date
           #in yyyy-MM-dd format) with the file name also containing date in it. When set to false, neither of these things
-          #happen and the output file gets stored under $outputFileLocation directly.
+          #happen and the output file gets stored under $outputFileLocation directly. When set to true _SUCCESS file is 
+          #written to $outputFileLocation/$runDate/_SUCCESS and when set to false it is written to 
+          #$outputFileLocation/_$runDate/_SUCCESS
           isOutputFileDateDriven=false
         }
 

--- a/src/main/resources/cloudfeeds-ballista.conf
+++ b/src/main/resources/cloudfeeds-ballista.conf
@@ -41,11 +41,13 @@ appConfig {
           #The class that extends the interface DBQuery which contains the query to be run to extract data from database.
           queryClass = com.rackspace.feeds.ballista.queries.PreferencesDBQuery
 
-          #When this field is set to true, app stores the final output file under $outputFileLocation/$runDate (run date
-          #in yyyy-MM-dd format) with the file name also containing date in it. When set to false, neither of these things
-          #happen and the output file gets stored under $outputFileLocation directly. When set to true _SUCCESS file is 
-          #written to $outputFileLocation/$runDate/_SUCCESS and when set to false it is written to 
-          #$outputFileLocation/_$runDate/_SUCCESS
+          #When 'true':
+          #   output file: $outputFileLocation/$runDate/$region_$dbName_$runDate.gz
+          #   SUCCESS: $outputFileLocation/$runDate/_SUCCESS
+          #
+          #When 'false"
+          #   output file: $outputFileLocation/$region_$dbName.gz
+          #   SUCCESS: $outputFileLocation/_$runDate/_SUCCESS
           isOutputFileDateDriven=false
         }
 

--- a/src/test/resources/cloudfeeds-ballista.conf
+++ b/src/test/resources/cloudfeeds-ballista.conf
@@ -2,7 +2,7 @@ appConfig {
 
   region = "ord"
   daysDataAvailable = 3
-  tempOutputDir = "/tmp"
+  tempOutputDir = "/tmp/temp"
   maxRowLimit = "10" //set this value to "ALL" for all rows
 
   export {
@@ -45,7 +45,7 @@ appConfig {
           queryClass = com.rackspace.feeds.ballista.queries.EntriesDBQuery
           isOutputFileDateDriven=true
         }
-        
+
         testdb {
           driverClass = "org.h2.Driver"
           jdbcUrl = "jdbc:h2:mem:test;INIT=runscript from 'classpath:scripts/create-tables.sql'\\;runscript from 'classpath:scripts/insert-data.sql'"
@@ -56,6 +56,18 @@ appConfig {
           fileNamePrefix = ${appConfig.region}
           queryClass = com.rackspace.feeds.ballista.TestEntriesDBQuery
           isOutputFileDateDriven=true
+        }
+
+        testdb1 {
+          driverClass = "org.h2.Driver"
+          jdbcUrl = "jdbc:h2:mem:test;INIT=runscript from 'classpath:scripts/create-tables.sql'\\;runscript from 'classpath:scripts/insert-data.sql'"
+          user = "root"
+          password = ""
+
+          outputFileLocation = "/tmp"
+          fileNamePrefix = ${appConfig.region}
+          queryClass = com.rackspace.feeds.ballista.TestEntriesDBQuery
+          isOutputFileDateDriven=false
         }
       }
     }

--- a/src/test/scala/com/rackspace/feeds/ballista/CommandProcessorTest.scala
+++ b/src/test/scala/com/rackspace/feeds/ballista/CommandProcessorTest.scala
@@ -4,12 +4,12 @@ import java.io.{ByteArrayOutputStream, FileOutputStream}
 
 import com.rackspace.feeds.ballista.config.CommandOptions
 import com.rackspace.feeds.ballista.service.{DefaultExportSvc, FSClient, LocalFSClient}
-import com.rackspace.feeds.ballista.util.SCPUtil
+import com.rackspace.feeds.ballista.util.{SCPSessionInfo, SCPUtil}
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormatter, DateTimeFormat}
 import org.junit.runner.RunWith
 import org.mockito.Matchers._
-import org.mockito.Mockito
+import org.mockito.{ArgumentCaptor, Mockito}
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -20,7 +20,7 @@ import scala.util.Try
 
 class CommandProcessorTestable(afsClient: LocalFSClient,
                                 ascpUtil: SCPUtil,
-                                testOutputLocationMap: mutable.HashMap[String, mutable.Set[String]] with mutable.MultiMap[String, String]) extends CommandProcessor {
+                                testOutputLocationMap: mutable.HashMap[String, mutable.Set[(String, Boolean)]] with mutable.MultiMap[String, (String, Boolean)]) extends CommandProcessor {
   override val scpUtil = ascpUtil
   override val outputLocationMap = testOutputLocationMap
   override val fsClient = afsClient
@@ -29,36 +29,47 @@ class CommandProcessorTestable(afsClient: LocalFSClient,
 @RunWith(classOf[JUnitRunner])
 class CommandProcessorTest extends FunSuite with MockitoSugar {
 
-  test("one _SUCCESS file should be created for each unique output location with desired content") {
+  test("one _SUCCESS file should be created for each unique output location and isOutputFileDateDriven flag with desired content") {
 
-    val testOutputLocationMap = new mutable.HashMap[String, mutable.Set[String]] with mutable.MultiMap[String, String]
-    testOutputLocationMap.addBinding("outLoc1", "prefs")
-    testOutputLocationMap.addBinding("outLoc1", "newrelic")
-    testOutputLocationMap.addBinding("outLoc2", "lbaas")
+    val testOutputLocationMap = new mutable.HashMap[String, mutable.Set[(String, Boolean)]] with mutable.MultiMap[String, (String, Boolean)]
+    testOutputLocationMap.addBinding("outLoc1", ("dbaas", true))
+    testOutputLocationMap.addBinding("outLoc1", ("newrelic", true))
+    testOutputLocationMap.addBinding("outLoc2", ("lbaas", true))
+    testOutputLocationMap.addBinding("outLoc2", ("prefs", false))
 
     val afsClient = mock[LocalFSClient]
-    val commandProcessor = new CommandProcessorTestable(afsClient, mock[SCPUtil], testOutputLocationMap)
+    val mockSCPUtil: SCPUtil = mock[SCPUtil]
+    val commandProcessor = new CommandProcessorTestable(afsClient, mockSCPUtil, testOutputLocationMap)
 
     val successFileContent = new ByteArrayOutputStream()
-    val resultMap = Map("prefs" -> 5.toLong, "newrelic" -> 4.toLong, "lbaas" -> 8.toLong)
+    val resultMap = Map("dbaas" -> 5.toLong, "newrelic" -> 4.toLong, "lbaas" -> 8.toLong, "prefs" -> 10.toLong)
     when(afsClient.getOutputStream(anyString())).thenReturn(successFileContent)
     commandProcessor.createSuccessFile(resultMap, DateTime.now())
     
-    verify(afsClient, times(2)).getOutputStream(anyString())
+    verify(afsClient, times(3)).getOutputStream(anyString())
 
+    val argumentCapture = ArgumentCaptor.forClass(classOf[String])
+    verify(mockSCPUtil, times(3)).scpFile(any[SCPSessionInfo](), anyString(), argumentCapture.capture(), anyString())
+
+    val runDateString = commandProcessor.getRunDateString(DateTime.now())
+    assert(argumentCapture.getAllValues.contains(s"outLoc1/$runDateString"), "Success file location for outLoc1(isOutputFileDateDriven=true) not present")
+    assert(argumentCapture.getAllValues.contains(s"outLoc2/$runDateString"), "Success file location for outLoc2(isOutputFileDateDriven=true) not present")
+    assert(argumentCapture.getAllValues.contains(s"outLoc2/${CommandProcessor.NON_DATA_FILE_PREFIX}$runDateString"), "Success file location for outLoc2(isOutputFileDateDriven=false) not present")
+    
     val successFileMap = successFileContent.toString.split("\n").map(x => {
       val keyVal = x.split("=")
       keyVal(0) -> keyVal(1).toLong
     }).toMap
 
-    assert(resultMap.get("prefs") == successFileMap.get("prefs"), "number of records exported, do not match with the number written to success file for prefs database")
+    assert(resultMap.get("dbaas") == successFileMap.get("dbaas"), "number of records exported, do not match with the number written to success file for dbaas database")
     assert(resultMap.get("newrelic") == successFileMap.get("newrelic"), "number of records exported, do not match with the number written to success file for newrelic database")
     assert(resultMap.get("lbaas") == successFileMap.get("lbaas"), "number of records exported, do not match with the number written to success file for lbaas database")
+    assert(resultMap.get("prefs") == successFileMap.get("prefs"), "number of records exported, do not match with the number written to success file for prefs database")
   }
   
   test("failure during processing of one database should not halt processing of other databases") {
     
-    val testOutputLocationMap = new mutable.HashMap[String, mutable.Set[String]] with mutable.MultiMap[String, String]
+    val testOutputLocationMap = new mutable.HashMap[String, mutable.Set[(String, Boolean)]] with mutable.MultiMap[String, (String, Boolean)]
     val afsClient = mock[LocalFSClient]
     val commandProcessor = spy(new CommandProcessorTestable(afsClient, mock[SCPUtil], testOutputLocationMap))
 
@@ -80,7 +91,7 @@ class CommandProcessorTest extends FunSuite with MockitoSugar {
 
   test("Should return zero as return code when no failures happen during processing") {
 
-    val testOutputLocationMap = new mutable.HashMap[String, mutable.Set[String]] with mutable.MultiMap[String, String]
+    val testOutputLocationMap = new mutable.HashMap[String, mutable.Set[(String, Boolean)]] with mutable.MultiMap[String, (String, Boolean)]
     val afsClient = mock[LocalFSClient]
     val commandProcessor = spy(new CommandProcessorTestable(afsClient, mock[SCPUtil], testOutputLocationMap))
 


### PR DESCRIPTION
 - Change in behavior for isOutputFileDateDriven flag
 - when isOutputFileDateDriven=false create _SUCCESS file in $outputFileLocation/_$runDate