### PR TITLE
CF-874 specify tenants to pull from DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The app expects the configuration files to be present at /etc/cloudfeeds-ballist
 
   -d <value> | --runDate <value>
          runDate is a date in the format yyyy-MM-dd. Data belonging to this date will be exported. Default value is yesterday.           
+  -t <value> | --tenantIds <value>
+        tenantIds is comma seprated list of tenant ids to be exported.  Default value is all data for all tenant ids.
   -n <value> | --dbNames <value>
          dbNames is comma separated list of database names to be exported. Default value is all the databases configured.           
   --dryrun

--- a/src/main/scala/com/rackspace/feeds/ballista/CommandProcessor.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/CommandProcessor.scala
@@ -126,8 +126,8 @@ class CommandProcessor {
     }
   }
 
-  def createQueryParams(commandOptions: CommandOptions): Map[String, DateTime] = {
-    Map("runDate" -> commandOptions.runDate)
+  def createQueryParams(commandOptions: CommandOptions): Map[String, Any] = {
+    Map("runDate" -> commandOptions.runDate, "tenantIds" -> commandOptions.tenantIds)
   }
 
   def export(queryParams: Map[String, Any], dbName: String): Try[(String, Long)] = {

--- a/src/main/scala/com/rackspace/feeds/ballista/config/CommandOptionsParser.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/config/CommandOptionsParser.scala
@@ -6,6 +6,7 @@ import scopt.Read
 
 case class CommandOptions(runDate: DateTime = DateTime.now.minusDays(1).withTimeAtStartOfDay(),
                           dbNames: Set[String] = AppConfig.export.from.dbs.dbConfigMap.keySet,
+                          tenantIds: Set[String] = null,
                           scponly: Boolean = false,
                           dryrun: Boolean = false)
 
@@ -50,6 +51,19 @@ object CommandOptionsParser {
           |Available dbNames for this configuration: ${dbNamesSet.mkString(",")}
         """.stripMargin.replaceAll("\n", " ")
       }
+    opt[Set[String]]('t', "tenantIds") action { (x, c) =>
+      c.copy(tenantIds = x)
+    } validate { tenantIds =>
+      if (tenantIds.size > 0)
+        success
+      else
+        failure(s"Tenant Ids must be specified and cannot be empty.")
+    } text {
+      s"""
+          |tenantIds is comma separated list of tenant ids.
+          |Data belonging to these tenant ids will be exported
+        """.stripMargin.replaceAll("\n", " ")
+    }
     opt[Unit]("scponly") action { (x, c) =>
       c.copy(scponly = true)
     } text {

--- a/src/main/scala/com/rackspace/feeds/ballista/config/CommandOptionsParser.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/config/CommandOptionsParser.scala
@@ -6,7 +6,7 @@ import scopt.Read
 
 case class CommandOptions(runDate: DateTime = DateTime.now.minusDays(1).withTimeAtStartOfDay(),
                           dbNames: Set[String] = AppConfig.export.from.dbs.dbConfigMap.keySet,
-                          tenantIds: Set[String] = null,
+                          tenantIds: Set[String] = Set.empty,
                           scponly: Boolean = false,
                           dryrun: Boolean = false)
 

--- a/src/main/scala/com/rackspace/feeds/ballista/queries/DBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/DBQuery.scala
@@ -21,4 +21,5 @@ trait DBQuery {
    * @return a database query to extract data
    */
   def fetch(runDate: DateTime, region: String, dataSource: DataSource, maxRowLimit: String): String
+  def fetch(runDate: DateTime, tenantIds: Set[String], region: String, dataSource: DataSource, maxRowLimit: String): String
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/queries/EntriesDBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/EntriesDBQuery.scala
@@ -17,7 +17,7 @@ class EntriesDBQuery extends DBQuery {
   val logger = LoggerFactory.getLogger(getClass)
   
   override def fetch(runDate: DateTime, region: String, dataSource: DataSource, maxRowLimit: String): String = {
-    this.fetch(runDate, null, region, dataSource, maxRowLimit)
+    this.fetch(runDate, Set.empty, region, dataSource, maxRowLimit)
   }
 
   override def fetch(runDate: DateTime, tenantIds: Set[String], region: String, dataSource: DataSource, maxRowLimit: String): String = {
@@ -31,7 +31,7 @@ class EntriesDBQuery extends DBQuery {
     }
 
     var whereClause = ""
-    if (tenantIds != null) {
+    if (tenantIds != Set.empty) {
       // escape each tenantId to prevent SQL injection
       val escapedTenantIds = tenantIds.map(tid => tid.replace("'", "''"))
       whereClause = "WHERE tenantid in ('" + escapedTenantIds.toArray.mkString("','") + "')"

--- a/src/main/scala/com/rackspace/feeds/ballista/queries/EntriesDBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/EntriesDBQuery.scala
@@ -17,28 +17,40 @@ class EntriesDBQuery extends DBQuery {
   val logger = LoggerFactory.getLogger(getClass)
   
   override def fetch(runDate: DateTime, region: String, dataSource: DataSource, maxRowLimit: String): String = {
+    this.fetch(runDate, null, region, dataSource, maxRowLimit)
+  }
+
+  override def fetch(runDate: DateTime, tenantIds: Set[String], region: String, dataSource: DataSource, maxRowLimit: String): String = {
     val tableName = getTableName(runDate, dataSource)
-    
-    logger.debug(s"Preparing query to extract data from partitioned entries table[$tableName] for runDate[$runDate]")
+
+    logger.debug(s"Preparing query to extract data from partitioned entries table[$tableName] for runDate[$runDate], tenantIds[$tenantIds]")
     val runDateStr = dateTimeFormatter.print(runDate)
-    
+
     if (!isTableExist(tableName, dataSource)) {
       throw new RuntimeException("Partitioned table[$tableName] does not exist")
     }
+
+    var whereClause = ""
+    if (tenantIds != null) {
+      // escape each tenantId to prevent SQL injection
+      val escapedTenantIds = tenantIds.map(tid => tid.replace("'", "''"))
+      whereClause = "WHERE tenantid in ('" + escapedTenantIds.toArray.mkString("','") + "')"
+    }
+
     s"""
-       | COPY (SELECT id, 
-       |              entryid, 
-       |              creationdate, 
-       |              datelastupdated, 
+       | COPY (SELECT id,
+       |              entryid,
+       |              creationdate,
+       |              datelastupdated,
        |              regexp_replace(entrybody, E'[\\n\\r]+', ' ', 'g') as entrybody,
        |              array_to_string( categories, '|' ) as categories,
-       |              eventtype, 
-       |              tenantid, 
+       |              eventtype,
+       |              tenantid,
        |              '$region' as region,
        |              '$runDateStr' as date,
        |              feed
-       |         FROM $tableName
-       |        limit $maxRowLimit)
+       |         FROM $tableName $whereClause
+       |         LIMIT $maxRowLimit)
        |   TO STDOUT
        | WITH DELIMITER $PG_DELIMITER
      """.stripMargin

--- a/src/main/scala/com/rackspace/feeds/ballista/queries/PreferencesDBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/PreferencesDBQuery.scala
@@ -3,6 +3,7 @@ package com.rackspace.feeds.ballista.queries
 import javax.sql.DataSource
 
 import org.joda.time.DateTime
+import org.apache.commons.lang3.NotImplementedException
 
 class PreferencesDBQuery extends DBQuery {
 
@@ -22,5 +23,7 @@ class PreferencesDBQuery extends DBQuery {
     
   }
   
-
+  override def fetch(runDate: DateTime, tenantIds: Set[String], region: String, dataSource: DataSource, maxRowLimit: String): String = {
+    throw new NotImplementedException("not implemented for PreferencesDBQuery")
+  }
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/queries/PreferencesDBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/PreferencesDBQuery.scala
@@ -8,6 +8,17 @@ import org.apache.commons.lang3.NotImplementedException
 class PreferencesDBQuery extends DBQuery {
 
   override def fetch(runDate: DateTime, region: String, dataSource: DataSource, maxRowLimit: String): String = {
+    this.fetch(runDate, Set.empty, region, dataSource, maxRowLimit)
+  }
+  
+  override def fetch(runDate: DateTime, tenantIds: Set[String], region: String, dataSource: DataSource, maxRowLimit: String): String = {
+    var whereClause = ""
+    if (tenantIds != Set.empty) {
+      // escape each tenantId to prevent SQL injection
+      val escapedTenantIds = tenantIds.map(tid => tid.replace("'", "''"))
+      whereClause = "WHERE id in ('" + escapedTenantIds.toArray.mkString("','") + "')"
+    }
+
     s"""
        | COPY (SELECT id,
        |              alternate_id,
@@ -15,15 +26,10 @@ class PreferencesDBQuery extends DBQuery {
        |              payload,
        |              created,
        |              updated
-       |         FROM preferences
+       |         FROM preferences $whereClause
        |        limit $maxRowLimit)
        |   TO STDOUT
        | WITH DELIMITER $PG_DELIMITER
      """.stripMargin
-    
-  }
-  
-  override def fetch(runDate: DateTime, tenantIds: Set[String], region: String, dataSource: DataSource, maxRowLimit: String): String = {
-    throw new NotImplementedException("not implemented for PreferencesDBQuery")
   }
 }

--- a/src/main/scala/com/rackspace/feeds/ballista/service/DefaultExportSvc.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/service/DefaultExportSvc.scala
@@ -83,7 +83,7 @@ class DefaultExportSvc(dbName: String) extends ExportSvc {
     val region = AppConfig.export.region
     val tenantIds = queryParams("tenantIds").asInstanceOf[Set[String]]
 
-    if (tenantIds != null) {
+    if (tenantIds != Set.empty) {
       // run fetch for specific tenantIds
       dbQuery.fetch(queryParams("runDate").asInstanceOf[DateTime], tenantIds, region, dataSource, AppConfig.export.maxRowLimit)
     }

--- a/src/main/scala/com/rackspace/feeds/ballista/service/DefaultExportSvc.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/service/DefaultExportSvc.scala
@@ -81,8 +81,17 @@ class DefaultExportSvc(dbName: String) extends ExportSvc {
   def getQuery(queryParams: Map[String, Any]) = {
     val dbQuery = getInstance(dbConfigMap(dbName)(DBProps.queryClass))
     val region = AppConfig.export.region
-  
-    dbQuery.fetch(queryParams("runDate").asInstanceOf[DateTime], region, dataSource, AppConfig.export.maxRowLimit)
+    val tenantIds = queryParams("tenantIds").asInstanceOf[Set[String]]
+
+    if (tenantIds != null) {
+      // run fetch for specific tenantIds
+      dbQuery.fetch(queryParams("runDate").asInstanceOf[DateTime], tenantIds, region, dataSource, AppConfig.export.maxRowLimit)
+    }
+    else {
+      // default run with out tenantIds filter
+      dbQuery.fetch(queryParams("runDate").asInstanceOf[DateTime], region, dataSource, AppConfig.export.maxRowLimit)
+    }
+
   }
 
   /**

--- a/src/test/scala/com/rackspace/feeds/ballista/config/CommandOptionsParserTest.scala
+++ b/src/test/scala/com/rackspace/feeds/ballista/config/CommandOptionsParserTest.scala
@@ -67,6 +67,16 @@ class CommandOptionsParserTest extends FunSuite {
       case None => 
     }
   }
+
+  test ("parsing validation should fail for missing tenantIds value") {
+    val args = Array[String]("-t")
+
+    CommandOptionsParser.getCommandOptions(args) match {
+      case Some(commandOptions) =>
+        fail("Parsing should not be successful with missing tenantIds value when using the -t switch")
+      case None =>
+    }
+  }
   
   Array[Array[String]](
     Array[String]("-n", ""),
@@ -97,16 +107,19 @@ class CommandOptionsParserTest extends FunSuite {
   test ("verify options sent from command line are being set correctly") {
     val runDate: DateTime = DateTime.now.minusDays(2).withTimeAtStartOfDay()
     val dbNames: Set[String] = AppConfig.export.from.dbs.dbConfigMap.keySet
+    val tenantIds = Set("tenant1", "tenant2", "tenant3", "tenant4")
 
     val runDateStr: String = dateTimePattern.print(runDate)
     val dbNamesStr: String = dbNames.mkString(",")
+    val tenantIdsStr: String = tenantIds.mkString(",")
 
-    val args = Array[String]("--runDate", runDateStr, "--dbNames", dbNamesStr, "--dryrun", "--scponly")
+    val args = Array[String]("--runDate", runDateStr, "--dbNames", dbNamesStr, "--tenantIds", tenantIdsStr, "--dryrun", "--scponly")
 
     CommandOptionsParser.getCommandOptions(args) match {
       case Some(commandOptions) =>
         assert(commandOptions.runDate === runDate, "runDate option is not set to the correct value")
         assert(commandOptions.dbNames === dbNames, "dbNames option is not set to the correct value")
+        assert(commandOptions.tenantIds === tenantIds, "tenantIds option is not set to the correct value")
         assert(commandOptions.dryrun === true, "dryrun option is not set to the correct value")
         assert(commandOptions.scponly === true, "scponly option is not set to the correct value")
       case None => fail("Unable to parse command options")


### PR DESCRIPTION
* add functionality and test, map to new switch -t and --tenantIds

e.g.
```
sh /opt/cloudfeeds-ballista/bin/cloudfeeds-ballista.sh -t tenantid1
sh /opt/cloudfeeds-ballista/bin/cloudfeeds-ballista.sh --tenantIds tenantid1,tenantid2
sh /opt/cloudfeeds-ballista/bin/cloudfeeds-ballista.sh -runDate 2015-06-19 -t "tenantid1, tenantid2, tenantid'3"
```
