### PR TITLE
CF-1024 remove \n from json payload when exporting

### DIFF
--- a/src/main/scala/com/rackspace/feeds/ballista/queries/PreferencesDBQuery.scala
+++ b/src/main/scala/com/rackspace/feeds/ballista/queries/PreferencesDBQuery.scala
@@ -23,7 +23,7 @@ class PreferencesDBQuery extends DBQuery {
        | COPY (SELECT id,
        |              alternate_id,
        |              json_extract_path_text(payload::json, 'enabled') as enabled,
-       |              payload,
+       |              regexp_replace(payload, E'[\\n\\r]+', ' ', 'g') as payload,
        |              created,
        |              updated
        |         FROM preferences $whereClause


### PR DESCRIPTION
@shintasmith @ChandraAddala @usnavi please review.

A one-line change in the SQL to extract preferences that will replace any return carriage and newlines with spaces during the ballista dump to hadoop, similar to what the feeds dump query is doing for entrybody in the EntriesDBQuery class.

I have built the rpm and tested it manually on my inova to make sure it works and strips out the newlines from the json payload.

After discussing with Chandra, it seems there's no easy way to add the integration tests in this project for the change because we're using H2 instead of postgres for the test database, and H2 does not support the regexp_replace function call.

We think that it'll be sufficient for Richard and Freddy to automate and test this feature with their test framework.